### PR TITLE
program did not work due to forgotten initialization

### DIFF
--- a/classcode/caesar/decoder.cpp
+++ b/classcode/caesar/decoder.cpp
@@ -7,7 +7,7 @@ using std::cout;
 string encode(string s, int r){
   char c;
   string result="";
-  for (int i ; i < s.length(); ++i) {
+  for (int i = 0; i < s.length(); ++i) {
     c = s[i];
     if (c >= 'a' && c<='z'){
       c  = c - 'a';


### PR DESCRIPTION
Changes made:
- initialized i in encode
   - without this, encode returns an empty string 
   - this means the whole program only prints the original string quote and "this is a test of"
- code works as intended now

Changes not made, but take note:
- values in freqs are 'wrong' due to bad macro snafu
   - doesn't really matter since they get implicitly casted to double anyways
- in distance formula:
   - you compare normalized (between 0 and 1) values to freqs, which is 0-100
   - it's like saying 20 is closer to 100 than 10, and that 2 is closer to 100 than 1
   - it works, but this isn't all that great... sort of defeats the point of normalizing?